### PR TITLE
Conditionally ignore cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- [#2] Conditionally ignore cache
+
 ### 1.0.1
 
 - [#1] Several small improvements.
@@ -9,3 +11,4 @@
 - Initial Implementation
 
 [#1]: https://github.com/godaddy/out-of-band-cache/pull/1
+[#2]: https://github.com/godaddy/out-of-band-cache/pull/2

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ await cache.get('data', { skipCache: true }, getter);
 ```
 
 The other method is conditionally choose not to remember certain items based on
-their value. This can be done via the `shouldCache` option. For example, here we
-are only remembering values that only `=== 'data'`;
+their value. This can be done via the `shouldCache` option. For example: here we
+are only remembering values that `=== 'data'`.
 
 ```js
 await cache.get('data', { shouldCache: value => value === 'data' }, getter);

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can instantiate the cache with 3 configurable options: `maxAge`, `maxStalene
 - `maxAge`: The duration, in milliseconds, before a cached item expires
 - `maxStaleness`: The duration, in milliseconds, in which expired cache items are still served
 - `fsCachePath`: (Optional) file path to create a file-system based cache
+- `shouldCache`: (Optional) a function to determine whether or not you will cache a found item
 
 ## Instantiation
 
@@ -81,10 +82,22 @@ If you get something that you would want to keep around for a while you can pass
 await cache.get('data', { maxAge: 120 * 60 * 1000 }, getter);
 ```
 
-Or you could elect to skip the cache entirely, going directly to `getter` for your data:
+## Ignoring the cache
+
+In some cases, you may want to modify how your `cache` remembers data.
+You can do this in two ways. The first is to skip the cache entirely, going
+directly to `getter` for your data. This can be done via the `skipCache` option:
 
 ```js
 await cache.get('data', { skipCache: true }, getter);
+```
+
+The other method is conditionally choose not to remember certain items based on
+their value. This can be done via the `shouldCache` option. For example, here we
+are only remembering values that only `=== 'data'`;
+
+```js
+await cache.get('data', { shouldCache: value => value === 'data' }, getter);
 ```
 
 ## Refreshing the Cache

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,12 @@ const MemoryStorage = require('./memory');
 const FSStorage = require('./fs');
 
 /**
+ * @typedef {(Object|String|Number|Boolean|Date)} JSONSerializable
+ */
+
+/**
  * @typedef GetResult
- * @prop {any} value The value of the cache item
+ * @prop {JSONSerializable} value The value of the cache item
  * @prop {Boolean} fromCache Whether the value was pulled from the cache or refreshed from the source API
  */
 
@@ -12,10 +16,6 @@ const FSStorage = require('./fs');
  * @callback ShouldCache
  * @param {GetResult} a cache item that we are electing to cache (or not)
  * @returns {Boolean}
- */
-
-/**
- * @typedef {(Object|String|Number|Boolean|Date)} JSONSerializable
  */
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,21 @@ const MemoryStorage = require('./memory');
 const FSStorage = require('./fs');
 
 /**
+ * @typedef GetResult
+ * @prop {any} value The value of the cache item
+ * @prop {Boolean} fromCache Whether the value was pulled from the cache or refreshed from the source API
+ */
+
+/**
+ * @callback ShouldCache
+ * @param {GetResult} a cache item that we are electing to cache (or not)
+ * @returns {Boolean}
+ */
+
+/**
  * @typedef {(Object|String|Number|Boolean|Date)} JSONSerializable
  */
+
 /**
  * Creates a cache object to be used for an Out of Band Cache
  *
@@ -12,6 +25,7 @@ const FSStorage = require('./fs');
  * @param {String} [opts.fsCachePath] - The path to use for file-system caching. Disables FS caching if omitted.
  * @param {Number} opts.maxAge        - The duration in milliseconds before a cached item expires.
  * @param {Number} opts.maxStaleness  - The duration in milliseconds in which expired cache items are still served.
+ * @param {ShouldCache} [opts.shouldCache]      - Function to determine whether to not we should cache the result
  * @returns {MultiLevelCache} a new cache object
  */
 module.exports = function Cache(opts) {
@@ -26,6 +40,7 @@ module.exports = function Cache(opts) {
   return new MultiLevelCache({
     maxAge: opts.maxAge,
     maxStaleness: opts.maxStaleness,
-    caches
+    caches,
+    shouldCache: opts.shouldCache
   });
 };

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -121,7 +121,7 @@ class MultiLevelCache {
 
         const willCache = shouldCache || this.shouldCache;
         if (typeof willCache !== 'function') {
-          throw new TypeError('willCache has to be a function');
+          throw new TypeError('shouldCache has to be a function');
         }
 
         // Given that we are not ignoring this value, perform an out-of-band cache update

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -121,7 +121,7 @@ class MultiLevelCache {
 
         // Given that we are not ignoring this value, perform an out-of-band cache update
         const willCache = shouldCache || this.shouldCache;
-        if (willCache(cacheItem.value)) {
+        if (typeof willCache === 'function' && willCache(cacheItem.value)) {
           // NB: an in-band update would `await` this Promise.all block
           Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
             throw new Error(`Error caching ${key}`, err);

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -121,7 +121,7 @@ class MultiLevelCache {
 
         // Given that we are not ignoring this value, perform an out-of-band cache update
         const willCache = shouldCache || this.shouldCache;
-        if (willCache(cacheItem)) {
+        if (willCache(cacheItem.value)) {
           // NB: an in-band update would `await` this Promise.all block
           Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
             throw new Error(`Error caching ${key}`, err);

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -45,6 +45,7 @@ class MultiLevelCache {
    * @param {Object}   opts                   - Options for this particular read
    * @param {Boolean}  [opts.skipCache=false] - Whether the cache should be bypassed (default false)
    * @param {String}   [opts.maxAge]          - The duration in milliseconds before a cached item expires
+   * @param {ShouldCache} [opts.shouldCache]  - A function to determine whether or not we should cache the item
    * @param {UpdateFn} updateFn               - async function that defines how to get a new value
    *
    * @async
@@ -100,7 +101,7 @@ class MultiLevelCache {
    * @param  {String} key       cache key
    * @param  {JSONSerializable} staleItem cache value
    * @param  {UpdateFn} updateFn  async function that defines how to get a new value
-   * @param  {ShouldCache} [shouldCache] function that determines whether or not we should cache
+   * @param  {ShouldCache} [shouldCache] function that determines whether or not we should cache the item
    *
    * @private
    * @async
@@ -119,7 +120,8 @@ class MultiLevelCache {
         };
 
         // Given that we are not ignoring this value, perform an out-of-band cache update
-        if (shouldCache || this.shouldCache(cacheItem)) {
+        const willCache = shouldCache || this.shouldCache;
+        if (willCache(cacheItem)) {
           // NB: an in-band update would `await` this Promise.all block
           Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
             throw new Error(`Error caching ${key}`, err);

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -119,15 +119,22 @@ class MultiLevelCache {
           expiry: Date.now() + this._maxAge
         };
 
-        // Given that we are not ignoring this value, perform an out-of-band cache update
         const willCache = shouldCache || this.shouldCache;
-        if (typeof willCache === 'function' && willCache(cacheItem.value)) {
+        if (typeof willCache !== 'function') {
+          throw new TypeError('willCache has to be a function');
+        }
+
+        // Given that we are not ignoring this value, perform an out-of-band cache update
+        if (willCache(cacheItem.value)) {
           // NB: an in-band update would `await` this Promise.all block
           Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
             throw new Error(`Error caching ${key}`, err);
           }).then(() => {
             delete this._pendingRefreshes[key];
           });
+        } else {
+          // just delete this right away because we're never caching the item
+          delete this._pendingRefreshes[key];
         }
 
         return { value, fromCache: false };

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -7,26 +7,28 @@
  */
 
 /**
-  * @callback UpdateFn
-  * @param {String} key The cache key
-  * @param {JSONSerializable} staleValue if cached, value that is currently in the cache for this key
-  * @returns {Promise<JSONSerializable>} Promise that resolves to the item value
-  * @async
-  */
+ * @callback UpdateFn
+ * @param {String} key The cache key
+ * @param {JSONSerializable} staleValue if cached, value that is currently in the cache for this key
+ * @returns {Promise<JSONSerializable>} Promise that resolves to the item value
+ * @async
+ */
 
 /**
  * A multi-level cache.
  *
- * @param {Object} opts                         - Options for the Client instance
- * @param {String} [opts.maxAge=600,000]        - The duration, in milliseconds, before a cached item expires
- * @param {String} [opts.maxStaleness=0]        - The duration, in milliseconds, in which expired cache items are still served
- * @param {Cache[]}  opts.caches                - An Array of cache objects. See `./fs` and `./memory` for sample caches.
+ * @param {Object} opts                             - Options for the Client instance
+ * @param {String} [opts.maxAge=600,000]            - The duration, in milliseconds, before a cached item expires
+ * @param {String} [opts.maxStaleness=0]            - The duration, in milliseconds, in which expired cache items are still served
+ * @param {ShouldCache} [opts.shouldCache=()=>true] - Function to determine whether to not we should cache the result
+ * @param {Cache[]}  opts.caches                    - An Array of cache objects. See `./fs` and `./memory` for sample caches.
  */
 class MultiLevelCache {
   constructor(opts) {
     this._maxAge = opts.maxAge || (10 * 60 * 1000);
     this._maxStaleness = opts.maxStaleness || 0;
     this._caches = opts.caches;
+    this.shouldCache = opts.shouldCache || (() => true);
 
     this._pendingRefreshes = {};
     this._initTask = Promise.all(opts.caches.map(cache => {
@@ -36,11 +38,6 @@ class MultiLevelCache {
     }));
   }
 
-  /**
-   * @typedef GetResult
-   * @prop {any} value The value of the cache item
-   * @prop {Boolean} fromCache Whether the value was pulled from the cache or refreshed from the source API
-   */
   /**
    * Attempts a cache get
    *
@@ -70,13 +67,13 @@ class MultiLevelCache {
         return getChain.catch(() => cache.get(key));
       }, Promise.reject());
     } catch (e) { // cache miss
-      return this._refresh(key, null, updateFn);
+      return this._refresh(key, null, updateFn, opts.shouldCache);
     }
 
     // cache hit
     const now = Date.now();
     if (item.expiry < now) {
-      const refreshTask = this._refresh(key, item, updateFn);
+      const refreshTask = this._refresh(key, item, updateFn, opts.shouldCache);
       if (item.expiry + this._maxStaleness < now) {
         return refreshTask;
       }
@@ -103,12 +100,13 @@ class MultiLevelCache {
    * @param  {String} key       cache key
    * @param  {JSONSerializable} staleItem cache value
    * @param  {UpdateFn} updateFn  async function that defines how to get a new value
+   * @param  {ShouldCache} [shouldCache] function that determines whether or not we should cache
    *
    * @private
    * @async
    * @returns {Promise<any>} a promise that resolves once we have refreshed the correct key
    */
-  async _refresh(key, staleItem, updateFn) {
+  async _refresh(key, staleItem, updateFn, shouldCache) {
     if (!(key in this._pendingRefreshes)) {
       try {
         const task = updateFn(key, staleItem && staleItem.value);
@@ -120,13 +118,15 @@ class MultiLevelCache {
           expiry: Date.now() + this._maxAge
         };
 
-        // Out-of-band cache update
-        // NB: an in-band update would `await` this Promise.all block
-        Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
-          throw new Error(`Error caching ${key}`, err);
-        }).then(() => {
-          delete this._pendingRefreshes[key];
-        });
+        // Given that we are not ignoring this value, perform an out-of-band cache update
+        if (shouldCache || this.shouldCache(cacheItem)) {
+          // NB: an in-band update would `await` this Promise.all block
+          Promise.all(this._caches.map(cache => cache.set(key, cacheItem))).catch(err => {
+            throw new Error(`Error caching ${key}`, err);
+          }).then(() => {
+            delete this._pendingRefreshes[key];
+          });
+        }
 
         return { value, fromCache: false };
 

--- a/lib/multi-level.js
+++ b/lib/multi-level.js
@@ -28,6 +28,11 @@ class MultiLevelCache {
     this._maxAge = opts.maxAge || (10 * 60 * 1000);
     this._maxStaleness = opts.maxStaleness || 0;
     this._caches = opts.caches;
+
+
+    if (opts.shouldCache && typeof opts.shouldCache !== 'function') {
+      throw new TypeError('shouldCache has to be a function');
+    }
     this.shouldCache = opts.shouldCache || (() => true);
 
     this._pendingRefreshes = {};
@@ -119,11 +124,11 @@ class MultiLevelCache {
           expiry: Date.now() + this._maxAge
         };
 
-        const willCache = shouldCache || this.shouldCache;
-        if (typeof willCache !== 'function') {
+        if (shouldCache && typeof shouldCache !== 'function') {
           throw new TypeError('shouldCache has to be a function');
         }
 
+        const willCache = shouldCache || this.shouldCache;
         // Given that we are not ignoring this value, perform an out-of-band cache update
         if (willCache(cacheItem.value)) {
           // NB: an in-band update would `await` this Promise.all block

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,7 +134,7 @@ describe('Out of Band cache', () => {
       try {
         await wonderland.get('tweedle-dum', { shouldCache: true }, simpleGet);
       } catch (e) {
-        assume(e).matches(/willCache has to be a function/);
+        assume(e).matches(/shouldCache has to be a function/);
         errors++;
       }
 
@@ -145,7 +145,7 @@ describe('Out of Band cache', () => {
       try {
         await wonderland.get('bandersnatch', { shouldCache: 'totally a function' }, simpleGet);
       } catch (e) {
-        assume(e).matches(/willCache has to be a function/);
+        assume(e).matches(/shouldCache has to be a function/);
         errors++;
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -217,4 +217,15 @@ describe('Out of Band cache', () => {
       assume(Object.entries(cache._pendingRefreshes)).has.length(0);
     });
   });
+
+  describe('reset', function () {
+    it('restores every cache', async function () {
+      const resetti = new Cache({});
+      await resetti.get('save file', {}, simpleGet);
+      await resetti.get('unsaved file', {}, simpleGet);
+      assume(resetti._caches[0]._items).has.length(2);
+      await resetti.reset();
+      assume(resetti._caches[0]._items).has.length(0);
+    });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,6 +156,17 @@ describe('Out of Band cache', () => {
       await wonderland.get('jabberwocky', { shouldCache: () => true }, simpleGet);
       assume(wonderland._caches[0]._items).has.length(2);
     });
+
+    it('does not set a cache item, even if we do it first', async function () {
+      const eventually = new Cache({});
+
+      await eventually.get('not yet', { skipCache: () => false }, simpleGet);
+      assume(eventually._caches[0]._items).has.length(0);
+
+      await eventually.get('not yet', {}, simpleGet);
+      await eventually.get('now', {}, simpleGet);
+      assume(eventually._caches[0]._items).has.length(2);
+    });
   });
 
   describe('_refresh', function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -124,17 +124,32 @@ describe('Out of Band cache', () => {
 
     it('only sets the cache values with shouldCache is a function', async function () {
       const wonderland = new Cache({});
+      let errors = 0;
 
       // default
       await wonderland.get('tweedle-dee', {}, simpleGet);
       assume(wonderland._caches[0]._items).has.length(1);
 
       // boolean
-      await wonderland.get('tweedle-dum', { shouldCache: true }, simpleGet);
+      try {
+        await wonderland.get('tweedle-dum', { shouldCache: true }, simpleGet);
+      } catch (e) {
+        assume(e).matches(/willCache has to be a function/);
+        errors++;
+      }
+
+      assume(errors).equals(1);
       assume(wonderland._caches[0]._items).has.length(1);
 
       // string
-      await wonderland.get('bandersnatch', { shouldCache: 'totally a function' }, simpleGet);
+      try {
+        await wonderland.get('bandersnatch', { shouldCache: 'totally a function' }, simpleGet);
+      } catch (e) {
+        assume(e).matches(/willCache has to be a function/);
+        errors++;
+      }
+
+      assume(errors).equals(2);
       assume(wonderland._caches[0]._items).has.length(1);
 
       // function

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,10 +107,20 @@ describe('Out of Band cache', () => {
 
     it('does not add an item if we supply shouldCache as a get option', async function () {
       const dopey = new Cache({});
-      
+
       await dopey.get('diamond', { shouldCache: () => false }, simpleGet);
       assume(dopey._caches[0]._items).has.length(0);
     });
+
+    it('does not add an item if it fails shouldCache', async function () {
+      const dopey = new Cache({ shouldCache: v => v !== 'words' });
+      // dopey doesn't know how to speak so he doesn't remember any words
+
+      await dopey.get('sounds', {}, simpleGet);
+      await dopey.get('words', {}, simpleGet);
+      await dopey.get('diamonds', {}, simpleGet);
+      assume(dopey._caches[0]._items).has.length(2);
+    })
   });
 
   describe('_refresh', function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -123,7 +123,7 @@ describe('Out of Band cache', () => {
     });
 
     it('only sets the cache values with shouldCache is a function', async function () {
-      const wonderland = new Cache({});
+      let wonderland = new Cache({});
       let errors = 0;
 
       // default
@@ -155,6 +155,16 @@ describe('Out of Band cache', () => {
       // function
       await wonderland.get('jabberwocky', { shouldCache: () => true }, simpleGet);
       assume(wonderland._caches[0]._items).has.length(2);
+
+      // in the constructor
+      try {
+        wonderland = new Cache({ shouldCache: 'definitely a function' });
+      } catch (e) {
+        assume(e).matches(/shouldCache has to be a function/);
+        errors++;
+      }
+
+      assume(errors).equals(3);
     });
 
     it('does not set a cache item, even if we do it first', async function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,7 +120,27 @@ describe('Out of Band cache', () => {
       await dopey.get('words', {}, simpleGet);
       await dopey.get('diamonds', {}, simpleGet);
       assume(dopey._caches[0]._items).has.length(2);
-    })
+    });
+
+    it('only sets the cache values with shouldCache is a function', async function () {
+      const wonderland = new Cache({});
+
+      // default
+      await wonderland.get('tweedle-dee', {}, simpleGet);
+      assume(wonderland._caches[0]._items).has.length(1);
+
+      // boolean
+      await wonderland.get('tweedle-dum', { shouldCache: true }, simpleGet);
+      assume(wonderland._caches[0]._items).has.length(1);
+
+      // string
+      await wonderland.get('bandersnatch', { shouldCache: 'totally a function' }, simpleGet);
+      assume(wonderland._caches[0]._items).has.length(1);
+
+      // function
+      await wonderland.get('jabberwocky', { shouldCache: () => true }, simpleGet);
+      assume(wonderland._caches[0]._items).has.length(2);
+    });
   });
 
   describe('_refresh', function () {

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -8,6 +8,14 @@ describe('In-memory cache', function () {
     assume(cache._items.abc).equals(123);
   });
 
+  it('recreates the _items if they were manually deleted', async function () {
+    const cache = new Cache();
+    delete cache._items;
+    assume(cache._items).does.not.exist();
+    cache.init();
+    assume(cache._items).exists();
+  });
+
   it('generates an empty item on initialization', async function () {
     const cache = new Cache();
     assume(cache._items).exists();


### PR DESCRIPTION
This PR introduces the `shouldCache` option into both the constructor and the `get` of the `out-of-band-cache`. Very simply, it allows you to determine whether or not you want to cache certain values *after* they come in.

Release of the code in this PR will be a **minor** release.