### PR TITLE
Allow users to use their own caching strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Allow consumers to use drivers for their own caches.
+
 ### 1.1.1
 
 - [#5] Allow for call-level age overrides as specified in the README.

--- a/README.md
+++ b/README.md
@@ -177,3 +177,53 @@ Fetched {"value":{"code":123465,"planet":"Druidia"},"fromCache":true} in 0ms
 Fetched {"value":{"code":123465,"planet":"Druidia"},"fromCache":true} in 0ms
 Fetched {"value":{"code":123465,"planet":"Druidia"},"fromCache":false} in 2001ms
 ```
+
+## Writing your own cache
+
+Let's say you want to add functionality to persist your cache in places other
+than just in memory and on disk. You can provide the `caches` option to provide
+additional persistence methods to your cache.
+
+```js
+const Cache = require('out-of-band-cache');
+const otherCache = require('./path/to/my/my-custom-cache');
+
+const caches = [ new otherCache(optionsToContructIt) ];
+
+const cache = new Cache({
+  maxAge: 10 * 60 * 1000,
+  maxStaleness: 60 * 60 * 1000,
+  caches
+});
+```
+
+Your new `otherCache` will then be used *after* the caches built in. In te above
+case it will be used as a fallback for the `memory` cache.
+
+If you want to ensure that your cache works properly, we have included a `mocha`
+suite that you can run directly on your cache:
+
+```js
+const cacheTest = require('out-of-band-cache/test/cache');
+const otherCache = require('./path/to/my/my-custom-cache');
+
+describe('MyCustomCache', function () {
+  it('is correctly consumed by out-of-band-cache', function () {
+    const options = {
+      beforeEach: function () {
+        // any setup that needs to be done before a test
+      },
+      afterEach: function () {
+        // any teardown that needs to be done after a test
+      },
+      constructor: otherCache,
+      builder: {
+        // any options that are needed to construct an otherCache
+      }
+    }
+
+    // run the mocha suite
+    cacheTest(options)();
+  });
+})
+```

--- a/README.md
+++ b/README.md
@@ -198,10 +198,51 @@ const cache = new Cache({
 ```
 
 Your new `otherCache` will then be used *after* the caches built in. In te above
-case it will be used as a fallback for the `memory` cache.
+case it will be used as a fallback for the `memory` cache. Your new cache must,
+at a minimum match the following spec to integrate properly with `out-of-band-cache`:
 
-If you want to ensure that your cache works properly, we have included a `mocha`
-suite that you can run directly on your cache:
+```js
+class MyCustomCache {
+  /**
+   * Initializes the cache. This may need to set up connections, create files, or
+   * something else that is needed before any other operations occur.
+   *
+   * @returns {Promise<void>} a Promise which resolves when initialization has completed.
+   */
+  async init() { }
+
+  /**
+   * Tries to retrieve a cache item from the existing cache
+   *
+   * @param {String} key - The cache key
+   * @returns {Promise<JSONSerializable>} a Promise which resolves if an item was found
+   * @throws {Error} an error that is thrown is the item cannot be found
+   */
+  async get(key) { }
+
+  /**
+   * Stores a cache item
+   *
+   * @param {String} key - The cache key
+   * @param {JSONSerializable} value  - The JSON-serializable value to store
+   * @returns {Promise<void>} a Promise which resolves once storage completes,
+   * or fails if there is an error writing the file.
+   */
+  async set(key, value) { }
+
+  /**
+   * Clears the cache entirely
+   *
+   * @returns {Promise<void>} a Promise which resolves once all cache files are
+   * deleted or fails if there was an error.
+   */
+  async reset() { }
+}
+```
+
+If you want to ensure that your cache works properly, we have included a test
+suite that you can run directly on your cache. **NB**, you will need to have
+`mocha` and `assume` already installed to use this test.
 
 ```js
 const cacheTest = require('out-of-band-cache/test/cache');
@@ -218,7 +259,8 @@ describe('MyCustomCache', function () {
       },
       constructor: otherCache,
       builder: {
-        // any options that are needed to construct an otherCache
+        // any options that are needed to construct an otherCache via
+        // new contructor(builder)
       }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,11 +21,12 @@ const FSStorage = require('./fs');
 /**
  * Creates a cache object to be used for an Out of Band Cache
  *
- * @param {Object} opts               - Options for the cache instance.
- * @param {String} [opts.fsCachePath] - The path to use for file-system caching. Disables FS caching if omitted.
- * @param {Number} opts.maxAge        - The duration in milliseconds before a cached item expires.
- * @param {Number} opts.maxStaleness  - The duration in milliseconds in which expired cache items are still served.
- * @param {ShouldCache} [opts.shouldCache]      - Function to determine whether to not we should cache the result
+ * @param {Object} opts                           - Options for the cache instance.
+ * @param {String} [opts.fsCachePath]             - The path to use for file-system caching. Disables FS caching if omitted.
+ * @param {Number} opts.maxAge                    - The duration in milliseconds before a cached item expires.
+ * @param {Number} opts.maxStaleness              - The duration in milliseconds in which expired cache items are still served.
+ * @param {ShouldCache} [opts.shouldCache]        - Function to determine whether to not we should cache the result
+ * @param {ShouldCache} [opts.caches[Cache]]      - An array of additional caches provided by the consumer of the application
  * @returns {MultiLevelCache} a new cache object
  */
 module.exports = function Cache(opts) {
@@ -35,6 +36,10 @@ module.exports = function Cache(opts) {
 
   if (opts.fsCachePath) {
     caches.push(new FSStorage({ path: opts.fsCachePath }));
+  }
+
+  if (opts.caches) {
+    caches.push(...opts.caches);
   }
 
   return new MultiLevelCache({

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,11 +26,11 @@ const FSStorage = require('./fs');
  * @param {Number} opts.maxAge                    - The duration in milliseconds before a cached item expires.
  * @param {Number} opts.maxStaleness              - The duration in milliseconds in which expired cache items are still served.
  * @param {ShouldCache} [opts.shouldCache]        - Function to determine whether to not we should cache the result
- * @param {ShouldCache} [opts.caches[Cache]]      - An array of additional caches provided by the consumer of the application
+ * @param {ShouldCache} [opts.fallback[Cache]]    - An array of additional caches provided by the consumer of the application
  * @returns {MultiLevelCache} a new cache object
  */
-module.exports = function Cache(opts) {
-  const caches = [
+function Cache(opts) {
+  let caches = [
     new MemoryStorage()
   ];
 
@@ -38,8 +38,12 @@ module.exports = function Cache(opts) {
     caches.push(new FSStorage({ path: opts.fsCachePath }));
   }
 
+  if (opts.fallback) {
+    caches.push(...opts.fallback);
+  }
+
   if (opts.caches) {
-    caches.push(...opts.caches);
+    caches = opts.caches;
   }
 
   return new MultiLevelCache({
@@ -48,4 +52,9 @@ module.exports = function Cache(opts) {
     caches,
     shouldCache: opts.shouldCache
   });
-};
+}
+
+Cache.Memory = MemoryStorage;
+Cache.File = FSStorage;
+
+module.exports = Cache;

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,19 +1,23 @@
-const path = require('path');
-const rimraf = require('rimraf');
 const assume = require('assume');
-const MemoryCache = require('../lib/memory');
-const FSCache = require('../lib/fs');
 
-const cacheDir = path.resolve(__dirname, '../.cache');
-function testInstance(constructor, opts) {
-  let cache;
+const defaults = {
+  beforeEach: () => {},
+  afterEach: () => {},
+  constructor: class dummy {},
+  builder: {}
+};
+
+module.exports = function testInstance(options) {
+  const opts = {
+    ...defaults,
+    ...options
+  };
+
+  const cache = new opts.constructor(opts.builder);
 
   return function () {
-    beforeEach(function (done) {
-      cache = new constructor(opts);
-
-      rimraf(cacheDir, done);
-    });
+    beforeEach(opts.beforeEach);
+    afterEach(opts.afterEach);
 
     it('init without any errors', async function () {
       await cache.init();
@@ -67,9 +71,4 @@ function testInstance(constructor, opts) {
 
     });
   };
-}
-
-describe('API-level functionality', function () {
-  describe('File System cache', testInstance(MemoryCache, {}));
-  describe('In-memory cache', testInstance(FSCache, { path: cacheDir }));
-});
+};

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,4 +1,5 @@
 const assume = require('assume');
+const { it } = require('mocha');
 
 const defaults = {
   beforeEach: () => {},
@@ -68,7 +69,6 @@ module.exports = function testInstance(options) {
       }
 
       assume(caught).is.truthy();
-
     });
   };
 };

--- a/test/fs.test.js
+++ b/test/fs.test.js
@@ -4,10 +4,13 @@ const rimraf = require('rimraf');
 const assume = require('assume');
 const sinon = require('sinon');
 const crypto = require('crypto');
-const FSCache = require('../lib/fs');
 const promisify = require('util').promisify;
 
+const FSCache = require('../lib/fs');
+const cacheTest = require('./cache');
+
 const readdir = promisify(fs.readdir);
+
 
 describe('File system cache', () => {
   const cacheDir = path.resolve(__dirname, '.cache');
@@ -66,5 +69,17 @@ describe('File system cache', () => {
 
     assume(caught).is.truthy();
     assume(cache._hashCache).has.length(0);
+  });
+
+  describe('API-level functionality', function () {
+    const opts = {
+      beforeEach: function (done) {
+        rimraf(cacheDir, done);
+      },
+      constructor: FSCache,
+      builder: { path: cacheDir }
+    };
+
+    cacheTest(opts)();
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,11 @@ describe('Out of Band cache', () => {
     rimraf(cachePath, done);
   });
 
+  it('exposes the memory and fs caches on the top level export', function () {
+    assume(Cache.Memory).exists();
+    assume(Cache.File).exists();
+  });
+
   it('does not prevent a failed request from being retried later on', async function () {
     const cache = new Cache({
       maxAge: 60 * 60 * 1000,

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,5 +1,6 @@
 const assume = require('assume');
 const Cache = require('../lib/memory');
+const cacheTest = require('./cache');
 
 describe('In-memory cache', function () {
   it('allows the cache to be pre-instantiated', function () {
@@ -56,5 +57,13 @@ describe('In-memory cache', function () {
     await cache.set('abc', 123);
     await cache.reset();
     assume(cache._items).has.length(0);
+  });
+
+  describe('API-level functionality', function () {
+    const opts = {
+      constructor: Cache
+    };
+
+    cacheTest(opts)();
   });
 });


### PR DESCRIPTION
If you want to persist your cache else where *in addition* to in memory or on disk, (s3, redis, level, etc...), you can now pass your own driver to make that happen. The only functional change to the code is in `lib/index.js`:

```js
if (opts.caches) {
  caches.push(...opts.caches);
}
```

This just allows an additional caches to be passed by the user. In order to facilitate people writing their own, I have done 2 things:

1. Added docs detailing the spec needed for the new driver
2. Refactored the test suite to be importable so users can run validation.