### PR TITLE
Update `shouldCache` type definition in index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,7 +16,7 @@ declare module 'out-of-band-cache' {
   interface SharedCacheProps<Value extends JSONSerializable> {
     maxAge?: number;
     maxStaleness?: number;
-    shouldCache?: (resultObj: GetResult<Value>) => boolean;
+    shouldCache?: (value: Value) => boolean;
   }
 
   type UpdateFn<Value extends JSONSerializable> = (


### PR DESCRIPTION
**Title**
TypeScript type definition for shouldCache doesn't match the implementation

**Description**
There's a mismatch between the TypeScript type definitions and the actual JavaScript implementation for the shouldCache callback option. 

This causes runtime errors when following the TypeScript types.
TypeScript Definition (typings/index.d.ts:19):
```
interface SharedCacheProps<Value extends JSONSerializable> {
  maxAge?: number;
  maxStaleness?: number;
  shouldCache?: (resultObj: GetResult<Value>) => boolean;
}

interface GetResult<Value extends JSONSerializable> {
  value: Value;
  fromCache: boolean;
}
```
Actual Implementation (lib/multi-level.js:172):
```
async _forceRefresh(key, staleItem, updateFn, opts) {
  try {
    const value = await updateFn(key, staleItem && staleItem.value);
    const cacheItem = {
      value,
      expiry: Date.now() + getValue(opts, 'maxAge', this._maxAge)
    };
    const shouldCache = getValue(opts, 'shouldCache', this.shouldCache);
    // ...
    if (shouldCache(cacheItem.value)) {  // ← Passes only the VALUE, not the result object
      // ...
    }
  }
}
```
The implementation passes only cacheItem.value (the raw value), not the full result object.

**Impact**
When developers follow the TypeScript types and write code like this:
```
const cache = new Cache({ maxAge: 60000 });

await cache.get(
  'myKey',
  {
    shouldCache: (result) => result.value !== null  // Following the TypeScript types
  },
  async () => {
    return null;  // Simulate a cache miss
  }
);
```
This results in a runtime error:
```
TypeError: Cannot read properties of null (reading 'value')
```

This proposed change simply fixes the TypeScript type declaration to match the actual runtime implementation